### PR TITLE
Adds actionable date to subscription params

### DIFF
--- a/app/controllers/solidus_subscriptions/api/v1/subscriptions_controller.rb
+++ b/app/controllers/solidus_subscriptions/api/v1/subscriptions_controller.rb
@@ -33,6 +33,7 @@ class SolidusSubscriptions::Api::V1::SubscriptionsController < Spree::Api::BaseC
 
   def subscription_params
     params.require(:subscription).permit(
+      :actionable_date,
       line_items_attributes: line_item_attributes,
       shipping_address_attributes: Spree::PermittedAttributes.address_attributes
     )


### PR DESCRIPTION
This is to accommodate https://github.com/geminimvp/theme_controlled_chaos/pull/144

Allows users to update their subscriptions delivery date from the front end.