### PR TITLE
Pass short index name to `add_reference` call

### DIFF
--- a/db/migrate/20181127022625_add_billing_address_id_to_solidus_subscriptions_subscriptions.rb
+++ b/db/migrate/20181127022625_add_billing_address_id_to_solidus_subscriptions_subscriptions.rb
@@ -1,7 +1,6 @@
 class AddBillingAddressIdToSolidusSubscriptionsSubscriptions < ActiveRecord::Migration[5.1]
   def change
-    add_reference :solidus_subscriptions_subscriptions, :billing_address
-    add_index :solidus_subscriptions_subscriptions, :billing_address_id, name: :index_subscription_billing_address_id
+    add_reference :solidus_subscriptions_subscriptions, :billing_address, index: { name: 'index_subscription_billing_address_id' }
     add_foreign_key :solidus_subscriptions_subscriptions, :spree_addresses, column: :billing_address_id
   end
 end


### PR DESCRIPTION
Postgresql requires index names to be <62 characters, so we have to
include a shorter index name when referencing longer table names.