### PR TITLE
Don't mark fails complete

### DIFF
--- a/app/models/solidus_subscriptions/failure_dispatcher.rb
+++ b/app/models/solidus_subscriptions/failure_dispatcher.rb
@@ -5,6 +5,8 @@ module SolidusSubscriptions
     def dispatch
       order.touch :completed_at
       order.cancel!
+      order.completed_at = nil
+      order.save
       installments.each { |i| i.failed!(order) }
       super
     end

--- a/app/models/solidus_subscriptions/payment_failed_dispatcher.rb
+++ b/app/models/solidus_subscriptions/payment_failed_dispatcher.rb
@@ -6,6 +6,8 @@ module SolidusSubscriptions
     def dispatch
       order.touch :completed_at
       order.cancel!
+      order.completed_at = nil
+      order.save
 
       installments.each { |i| i.payment_failed!(order) }
       super

--- a/spec/features/purchase_cycle_spec.rb
+++ b/spec/features/purchase_cycle_spec.rb
@@ -65,7 +65,7 @@ RSpec.feature 'Subscription purchase cycle', type: :feature do
   end
 
   def fill_in_payment_info
-    fill_in "Card Number", with: "4111 1111 1111 1111"
+    fill_in "Card Number", with: "1"
     fill_in "Expiration", with: "01/25"
     fill_in "Card Code", with: "123"
   end

--- a/spec/models/solidus_subscriptions/failure_dispatcher_spec.rb
+++ b/spec/models/solidus_subscriptions/failure_dispatcher_spec.rb
@@ -22,5 +22,10 @@ RSpec.describe SolidusSubscriptions::FailureDispatcher do
     it 'cancels the order' do
       expect { subject }.to change { order.state }.to 'canceled'
     end
+
+    it 'does not set completed_at' do
+      subject
+      expect(order.reload.completed_at).to be_nil
+    end
   end
 end

--- a/spec/models/solidus_subscriptions/payment_failed_dispatcher_spec.rb
+++ b/spec/models/solidus_subscriptions/payment_failed_dispatcher_spec.rb
@@ -26,5 +26,10 @@ RSpec.describe SolidusSubscriptions::PaymentFailedDispatcher do
     it 'cancels the order' do
       expect { subject }.to change { order.state }.to 'canceled'
     end
+
+    it 'does not set completed_at' do
+      subject
+      expect(order.reload.completed_at).to be_nil
+    end
   end
 end


### PR DESCRIPTION
See commit comments for details on the why and what of this change. I have 2 pre-commits that resolve some minor deprecations, which I can extract to separate PRs if we think the overhead is worth it.