### PR TITLE
Set frontend_viewable to false on failure

### DIFF
--- a/app/models/solidus_subscriptions/failure_dispatcher.rb
+++ b/app/models/solidus_subscriptions/failure_dispatcher.rb
@@ -6,6 +6,7 @@ module SolidusSubscriptions
       order.touch :completed_at
       order.cancel!
       order.completed_at = nil
+      order.frontend_viewable = false
       order.save
       installments.each { |i| i.failed!(order) }
       super

--- a/app/models/solidus_subscriptions/payment_failed_dispatcher.rb
+++ b/app/models/solidus_subscriptions/payment_failed_dispatcher.rb
@@ -7,6 +7,7 @@ module SolidusSubscriptions
       order.touch :completed_at
       order.cancel!
       order.completed_at = nil
+      order.frontend_viewable = false
       order.save
 
       installments.each { |i| i.payment_failed!(order) }

--- a/spec/models/solidus_subscriptions/failure_dispatcher_spec.rb
+++ b/spec/models/solidus_subscriptions/failure_dispatcher_spec.rb
@@ -27,5 +27,10 @@ RSpec.describe SolidusSubscriptions::FailureDispatcher do
       subject
       expect(order.reload.completed_at).to be_nil
     end
+
+    it 'sets frontend_viewable to false' do
+      subject
+      expect(order.frontend_viewable).to be_falsey
+    end
   end
 end

--- a/spec/models/solidus_subscriptions/payment_failed_dispatcher_spec.rb
+++ b/spec/models/solidus_subscriptions/payment_failed_dispatcher_spec.rb
@@ -31,5 +31,10 @@ RSpec.describe SolidusSubscriptions::PaymentFailedDispatcher do
       subject
       expect(order.reload.completed_at).to be_nil
     end
+
+    it 'sets frontend_viewable to false' do
+      subject
+      expect(order.frontend_viewable).to be_falsey
+    end
   end
 end


### PR DESCRIPTION
When an installment order fails to process, we need to set
`frontend_viewable` to false so that the order is not picked up as a
user's last incomplete order later.