### PR TITLE
Set completed_at on failed orders

### DIFF
--- a/app/models/solidus_subscriptions/failure_dispatcher.rb
+++ b/app/models/solidus_subscriptions/failure_dispatcher.rb
@@ -5,7 +5,6 @@ module SolidusSubscriptions
     def dispatch
       order.touch :completed_at
       order.cancel!
-      order.completed_at = nil
       order.frontend_viewable = false
       order.save
       installments.each { |i| i.failed!(order) }

--- a/app/models/solidus_subscriptions/payment_failed_dispatcher.rb
+++ b/app/models/solidus_subscriptions/payment_failed_dispatcher.rb
@@ -6,7 +6,6 @@ module SolidusSubscriptions
     def dispatch
       order.touch :completed_at
       order.cancel!
-      order.completed_at = nil
       order.frontend_viewable = false
       order.save
 

--- a/spec/models/solidus_subscriptions/failure_dispatcher_spec.rb
+++ b/spec/models/solidus_subscriptions/failure_dispatcher_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe SolidusSubscriptions::FailureDispatcher do
       expect { subject }.to change { order.state }.to 'canceled'
     end
 
-    it 'does not set completed_at' do
+    it 'sets completed_at' do
       subject
-      expect(order.reload.completed_at).to be_nil
+      expect(order.reload.completed_at).to be_present
     end
 
     it 'sets frontend_viewable to false' do

--- a/spec/models/solidus_subscriptions/payment_failed_dispatcher_spec.rb
+++ b/spec/models/solidus_subscriptions/payment_failed_dispatcher_spec.rb
@@ -27,9 +27,9 @@ RSpec.describe SolidusSubscriptions::PaymentFailedDispatcher do
       expect { subject }.to change { order.state }.to 'canceled'
     end
 
-    it 'does not set completed_at' do
+    it 'sets completed_at' do
       subject
-      expect(order.reload.completed_at).to be_nil
+      expect(order.reload.completed_at).to be_present
     end
 
     it 'sets frontend_viewable to false' do


### PR DESCRIPTION
Removing this value caused all sorts of crazy problems: customers
getting these orders set to their open carts, etc. We need to roll this
specific change back for the good of the country.