### PR TITLE
Prevent installment stacking

### DIFF
--- a/lib/solidus_subscriptions/processor.rb
+++ b/lib/solidus_subscriptions/processor.rb
@@ -57,11 +57,11 @@ module SolidusSubscriptions
     # instance
     def build_jobs
       users.map do |user|
-        installemts_by_address_and_user = installments(user).group_by do |i|
+        installments_by_address_and_user = installments(user).group_by do |i|
           i.subscription.shipping_address_id
         end
 
-        installemts_by_address_and_user.values.each do |grouped_installments|
+        installments_by_address_and_user.values.each do |grouped_installments|
           ProcessInstallmentsJob.perform_later grouped_installments.map(&:id)
         end
       end
@@ -96,8 +96,8 @@ module SolidusSubscriptions
           sub.advance_actionable_date
           sub.cancel! if sub.pending_cancellation?
           sub.deactivate! if sub.can_be_deactivated?
-          sub.installments.create!
-        end
+          sub.installments.create! if sub.installments.actionable.empty?
+        end.compact
       end
     end
 

--- a/spec/lib/solidus_subscriptions/processor_spec.rb
+++ b/spec/lib/solidus_subscriptions/processor_spec.rb
@@ -117,5 +117,28 @@ RSpec.describe SolidusSubscriptions::Processor, :checkout do
   describe '#build_jobs' do
     subject { described_class.new([user]).build_jobs }
     it_behaves_like 'a subscription order'
+
+    context 'when a user has an old unfulfilled installment' do
+      let!(:failed_user) { create :user, :subscription_user }
+      let!(:fail_credit_card) {
+        card = create(:credit_card, gateway_customer_profile_id: 'BGS-123', user: failed_user)
+        wallet_payment_source = failed_user.wallet.add(card)
+        failed_user.wallet.default_wallet_payment_source = wallet_payment_source
+        failed_user.save
+        card
+      }
+
+      let!(:failed_installment) do
+        create(:installment, :failed, created_at: 2.months.ago, subscription_traits: [actionable_date: 1.day.ago, created_at: 2.months.ago, user: failed_user])
+      end
+      let(:failed_subscription) { failed_installment.subscription }
+
+      it 'does not create a new installment' do
+        expect {
+          described_class.new([failed_user]).build_jobs
+        }.to_not change(SolidusSubscriptions::Installment, :count)
+      end
+
+    end
   end
 end


### PR DESCRIPTION
Recently, one of our customers reported that they observed a
subscription installment order on their account for qty. 2 of the
subscribed item, when they expected qty. 1. Investigation revealed that
their subscription (1 per month) had been without valid payment information for >1
month. Because of this, when they finally added valid payment info their
order covered 2 installments in effect "catching them up" for the missed
installments. This behavior is confusing for the customer, so we want to
change it slightly. Here, we skip creation of a new installment if the
subscription already has any actionable installments.