### PR TITLE
Feature/persist subscription addresses

### DIFF
--- a/spec/controllers/solidus_subscriptions/api/v1/subscriptions_controller_spec.rb
+++ b/spec/controllers/solidus_subscriptions/api/v1/subscriptions_controller_spec.rb
@@ -79,6 +79,13 @@ RSpec.describe SolidusSubscriptions::Api::V1::SubscriptionsController, type: :co
 
         it { is_expected.to have_http_status(:unprocessable_entity) }
       end
+
+      context 'when an address is being updated' do
+        it 'persists the address to the users address book' do
+          expect { subject }.to change { user.addresses.count }.by(1)
+          expect(user.addresses.last).to eq(subscription.reload.shipping_address)
+        end
+      end
     end
 
     context 'when the subscription belongs to someone else' do


### PR DESCRIPTION
This will persist the addresses that are added to the subscription when it is updated to match what happens in checkout. 