### PR TITLE
Add subscription role classes [branch ch4098]

### DIFF
--- a/lib/solidus_subscriptions.rb
+++ b/lib/solidus_subscriptions.rb
@@ -2,5 +2,8 @@ require 'solidus'
 require 'solidus_support'
 require "solidus_subscriptions/ability"
 require 'solidus_subscriptions/engine'
+require 'solidus_subscriptions/permission_sets/base'
+require 'solidus_subscriptions/permission_sets/subscription_display'
+require 'solidus_subscriptions/permission_sets/subscription_management'
 require 'deface'
 require 'state_machines'

--- a/lib/solidus_subscriptions/permission_sets/base.rb
+++ b/lib/solidus_subscriptions/permission_sets/base.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module SolidusSubscriptions
+  module PermissionSets
+    # This is the base class used for crafting permission sets.
+    #
+    # This is used by {Spree::RoleConfiguration} when adding custom behavior to {Spree::Ability}.
+    # See one of the subclasses for example structure such as {Spree::PermissionSets::UserDisplay}
+    #
+    # @see Spree::RoleConfiguration
+    # @see Spree::PermissionSets
+    class Base
+      # @param ability [CanCan::Ability]
+      #   The ability that will be extended with the current permission set.
+      #   The ability passed in must respond to #user
+      def initialize(ability)
+        @ability = ability
+      end
+
+      # Activate permissions on the ability. Put your can and cannot statements here.
+      # Must be overriden by subclasses
+      def activate!
+        raise NotImplementedError.new
+      end
+
+      private
+
+      attr_reader :ability
+      delegate :can, :cannot, :user, to: :ability
+    end
+  end
+end

--- a/lib/solidus_subscriptions/permission_sets/subscription_display.rb
+++ b/lib/solidus_subscriptions/permission_sets/subscription_display.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module SolidusSubscriptions
+  module PermissionSets
+    class SubscriptionDisplay < PermissionSets::Base
+      def activate!
+        can :display, SolidusSubscriptions::Subscription
+      end
+    end
+  end
+end

--- a/lib/solidus_subscriptions/permission_sets/subscription_management.rb
+++ b/lib/solidus_subscriptions/permission_sets/subscription_management.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module SolidusSubscriptions
+  module PermissionSets
+    class SubscriptionManagement < PermissionSets::Base
+      def activate!
+        can :manage, SolidusSubscriptions::Subscription
+      end
+    end
+  end
+end

--- a/spec/lib/solidus_subscriptions/permission_sets/subscription_display_spec.rb
+++ b/spec/lib/solidus_subscriptions/permission_sets/subscription_display_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "cancan/matchers"
+
+RSpec.describe SolidusSubscriptions::PermissionSets::SubscriptionDisplay do
+  let(:ability) { DummyAbility.new }
+
+  subject { ability }
+
+  context 'when activated' do
+    before do
+      described_class.new(ability).activate!
+    end
+
+    it { is_expected.to be_able_to(:display, SolidusSubscriptions::Subscription) }
+  end
+
+  context 'when not activated' do
+    it { is_expected.not_to be_able_to(:display, SolidusSubscriptions::Subscription) }
+  end
+end

--- a/spec/lib/solidus_subscriptions/permission_sets/subscription_management_spec.rb
+++ b/spec/lib/solidus_subscriptions/permission_sets/subscription_management_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "cancan/matchers"
+
+RSpec.describe SolidusSubscriptions::PermissionSets::SubscriptionManagement do
+  let(:ability) { DummyAbility.new }
+
+  subject { ability }
+
+  context 'when activated' do
+    before do
+      described_class.new(ability).activate!
+    end
+
+    it { is_expected.to be_able_to(:manage, SolidusSubscriptions::Subscription) }
+  end
+
+  context 'when not activated' do
+    it { is_expected.not_to be_able_to(:manage, SolidusSubscriptions::Subscription) }
+  end
+end

--- a/spec/support/dummy_ability.rb
+++ b/spec/support/dummy_ability.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'cancan'
+
+class DummyAbility
+  include CanCan::Ability
+end


### PR DESCRIPTION
Adds subscription permission sets that can be used by spree_user_roles.