### PR TITLE
Add total_cost to subscription model

### DIFF
--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -210,6 +210,12 @@ module SolidusSubscriptions
       end
     end
 
+    def total_cost
+      line_items.reduce(0.0) do |total_cost, line_item|
+        total_cost + line_item.spree_line_item.try(:total).to_f
+      end
+    end
+
     private
 
     def check_successive_skips_exceeded


### PR DESCRIPTION
Add total cost for a subscription to be used in user-facing sub management.

needed for https://github.com/geminimvp/engine_storefront/pull/823/files