### PR TITLE
Migrate from chromedriver-helper to webdrivers

### DIFF
--- a/solidus_subscriptions.gemspec
+++ b/solidus_subscriptions.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'capybara-screenshot'
-  s.add_development_dependency 'chromedriver-helper'
   s.add_development_dependency 'coffee-rails'
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'factory_bot'
@@ -44,5 +43,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sqlite3', '~> 1.3.6'
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'versioncake'
+  s.add_development_dependency 'webdrivers'
   s.add_development_dependency 'yard'
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,21 +1,23 @@
 require 'capybara/rspec'
 require 'capybara-screenshot/rspec'
-require 'chromedriver-helper'
+require 'webdrivers'
+Webdrivers::Chromedriver.update
 
-Chromedriver.set_version '2.45'
+RSpec.configure do |config|
+  config.include Rack::Test::Methods, type: :requests
 
-RSpec.configure do |_config|
   Capybara.server_port = 8888 + ENV['TEST_ENV_NUMBER'].to_i
+
   Capybara.javascript_driver = :selenium
   Capybara.register_driver :selenium do |app|
-    capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-      chromeOptions: {
-        args: %w[ headless disable-gpu ]
-      }
+    driver_options = Selenium::WebDriver::Chrome::Options.new(
+      args: %w[ headless disable-gpu window-size=1280,1024 ]
     )
-    Capybara::Selenium::Driver.new(app,
-                                   browser: :chrome,
-                                   desired_capabilities: capabilities
-                                  )
-  end
+
+    Capybara::Selenium::Driver.new(
+			app,
+			browser: :chrome,
+      options: driver_options
+		)
+	end
 end


### PR DESCRIPTION
It looks like `chromedriver-helper` is officially out of date, so we
should migrate to `webdrivers`.