### PR TITLE
Correct subscription typos

### DIFF
--- a/apidoc/configuration.md
+++ b/apidoc/configuration.md
@@ -52,7 +52,7 @@ SolidusSubscriptions::Config.subscription_line_item_attributes = [
 # subclass from the the dispatcher you are replacing, and call super
 # from within the #dispatch method (if you override it)
 
-# This handler is called when a susbcription order is successfully placed.
+# This handler is called when a subscription order is successfully placed.
 SolidusSubscriptions::Config.success_dispatcher_class = ::SolidusSubscriptions::SuccessDispatcher
 
 # This handler is called when an order cant be placed for a group of installments

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,8 +13,8 @@ en:
         This installment could not be processed because of insufficient
         stock.
       success: This installment has been processed successfully!
-      failed: This installment could not be processed
-      payment_failed: The payment for this installment failed
+      failed: This installment could not be processed.
+      payment_failed: The payment for this installment failed.
 
   spree:
     new_subscription: New Subscription

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,7 +35,7 @@ en:
           new_subscription: New Subscription
         edit:
           back: Back to Subscriptions List
-          title: Edit a Susbcription
+          title: Edit a Subscription
           customer: Customer
           status: Status
           fulfillment_status: Fulfillment Status
@@ -43,7 +43,7 @@ en:
           interval: Interval
         new:
           back: Back to Subscriptions List
-          title: Create a Susbcription
+          title: Create a Subscription
         form:
           subscription: Subscription
           subscription_line_item: Subscription Line Item

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,8 +13,8 @@ en:
         This installment could not be processed because of insufficient
         stock.
       success: This installment has been processed successfully!
-      failed: This installment could not be processed.
-      payment_failed: The payment for this installment failed.
+      failed: This installment could not be processed
+      payment_failed: The payment for this installment failed
 
   spree:
     new_subscription: New Subscription

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,9 +28,9 @@ en:
             skip: Skip One
 
       subscriptions:
-        successfully_canceled: Subsciption Canceled!
-        successfully_activated: Subsciption Activated!
-        successfully_skipped: Subsciption delayed until %{date}
+        successfully_canceled: Subscription Canceled!
+        successfully_activated: Subscription Activated!
+        successfully_skipped: Subscription delayed until %{date}
         index:
           new_subscription: New Subscription
         edit:

--- a/lib/solidus_subscriptions/config.rb
+++ b/lib/solidus_subscriptions/config.rb
@@ -6,7 +6,7 @@ module SolidusSubscriptions
       # subclass from the the dispatcher you are replacing, and call super
       # from within the #dispatch method (if you override it)
       #
-      # This handler is called when a susbcription order is successfully placed.
+      # This handler is called when a subscription order is successfully placed.
       attr_writer :success_dispatcher_class
       def success_dispatcher_class
         @success_dispatcher_class ||= ::SolidusSubscriptions::SuccessDispatcher


### PR DESCRIPTION
Fix all typos of "Subscription" in subheader, config file, and yml file

*BEFORE*
![Screen Shot 2019-11-04 at 9 58 08 AM](https://user-images.githubusercontent.com/40967205/68141126-2e0e4400-feea-11e9-8e06-030ffc5097fd.png)

*AFTER*
![Screen Shot 2019-11-04 at 10 03 06 AM](https://user-images.githubusercontent.com/40967205/68141227-56963e00-feea-11e9-87e9-7e59175834e9.png)