### PR TITLE
WIP Add user.bill_address as third backup in case no ship_address

### DIFF
--- a/app/models/solidus_subscriptions/checkout.rb
+++ b/app/models/solidus_subscriptions/checkout.rb
@@ -71,7 +71,6 @@ module SolidusSubscriptions
         order.update!
       end
       apply_promotions
-
       order.checkout_steps[0...-1].each do
         if order.state == "address"
           order.bill_address = bill_address
@@ -81,6 +80,9 @@ module SolidusSubscriptions
         order.next!
       end
 
+      if order.failed
+        console.log('order failed')
+      end
       # Do this as a separate "quiet" transition so that it returns true or
       # false rather than raising a failed transition error
       order.complete
@@ -118,7 +120,8 @@ module SolidusSubscriptions
     end
 
     def ship_address
-      subscription.shipping_address || user.ship_address
+      # subscription.shipping_address || user.ship_address
+      subscription.shipping_address || user.ship_address || user.bill_address
     end
 
     def bill_address

--- a/app/models/solidus_subscriptions/checkout.rb
+++ b/app/models/solidus_subscriptions/checkout.rb
@@ -80,9 +80,6 @@ module SolidusSubscriptions
         order.next!
       end
 
-      if order.failed
-        console.log('order failed')
-      end
       # Do this as a separate "quiet" transition so that it returns true or
       # false rather than raising a failed transition error
       order.complete


### PR DESCRIPTION
Add user.bill_address as third backup plan in case there is no ship_address

[ch5585]

**Error:** Cannot transition state via :next from :address (Reason(s): Valid shipping address required)

**Findings/Notes:**
- Started happening May 24th, 2019 (when rollbar errors first started occurring) - https://rollbar.com/enginecommerce/engine_storefront/items/149/?item_page=0&#instances
- Luke confirmed through controlled_chaos db that the controlled chaos failed subs were imported at different times
- That specific rollbar error stopped occurring July 15th, but the deploy on engine-cchaos-prod didn't show anything relevant to this card

*Files in solidus_subscriptions:*
- `subscription.rb`: groups together the information required for the system to place a subscriptions order on behalf of a specific user
- `installment.rb`: a single iteration of a subscription. Fulfilled by a completed order
- `process_installments_job.rb`: inherits from ActiveJob::Base. Creates a consolidated installment from a list of installments and processes them. Then moves on to "Checkout"
- `checkout.rb`: where the installments are processed

*Files in engine_storefront:*
- `subscription_generator_decorator.rb`
- `subscription_decorator.rb`
- `ModifySubscriptionModal.js:` the modal in Admin to update Payment & Shipping

**Run Test App**
In *solidus_subscriptions*, run `bundle exec rake`

**Process Subscriptions Manually**
In *engine_storefront*, run `bundle exec rake solidus_subscriptions:process`

**Check controlled_chaos db**
In terminal, run `heroku run rails c -a engine-cchaos-prod` (*However, I don't have permissions)

**Access/Manipulate Subscriptions & Installments in Rails Console**
In *engine_storefront*, run `bundle exec rails console`
- Last/most recent installment: `SolidusSubscriptions::Installment.last`
- Installment details: `SolidusSubscriptions::Installment.last.details`
- Check unfulfilled installments: `SolidusSubscriptions::Installment.unfulfilled`
- Save last installment: `SolidusSubscriptions::Installment.last.save`
- Check last installment actionable_date: `SolidusSubscriptions::Installment.last.subscription.actionable_date`
- Find a certain subscription by ID: `SolidusSubscriptions::Subscription.find(ID#)`
- Process an installment: `SolidusSubscriptions::Checkout.new([SolidusSubscriptions::Installment.last)].process`
- Update the last installment's actionable_date to yesterday: `SolidusSubscriptions::Installment.last.subscription.update(actionable_date: Date.yesterday)`

**Debug in Rails Console**
In `Checkout.rb` file insert `binding.pry`
In *engine_storefront*, run `bundle exec rails console`
In *engine_storefront*, run `SolidusSubscriptions::Checkout.new([SolidusSubscriptions::Installment.last]).process`

**Debug with mysql commands in DB**
In engine_storefront, run `bundle exec rails dbconsole`
- To view all existing tables in DB: `\dt`
- To view specific table in DB: `\d [table name]`
- To view specific data in table: `SELECT [attribute] FROM [table]` (ex. `SELECT id, user_id, shipping_address_id, billing_address_id FROM solidus_subscriptions_subscriptions;`)

**DB Tables**
*solidus_subscriptions_subscriptions*
NOTE: no billing_address_id nor shipping_address_id for any of the newly created subscriptions (from the Admin)
![Screen Shot 2019-11-05 at 2 56 24 PM](https://user-images.githubusercontent.com/40967205/68249663-79088400-ffdc-11e9-82e2-8b7e5f12c598.png)
![Screen Shot 2019-11-05 at 4 47 17 PM](https://user-images.githubusercontent.com/40967205/68255960-f25ba300-ffeb-11e9-9e84-12a1fee27244.png)

*spree_users*
![Screen Shot 2019-11-05 at 2 59 47 PM](https://user-images.githubusercontent.com/40967205/68249894-f3d19f00-ffdc-11e9-8977-77caf34a43a2.png)

*spree_user_addresses*
![Screen Shot 2019-11-05 at 3 00 35 PM](https://user-images.githubusercontent.com/40967205/68249959-0e0b7d00-ffdd-11e9-9ac9-d9bf6e278f9b.png)
![Screen Shot 2019-11-05 at 4 36 00 PM](https://user-images.githubusercontent.com/40967205/68255431-6bf29180-ffea-11e9-8024-cfde0380abb2.png)

*spree_addresses*
![Screen Shot 2019-11-05 at 3 01 12 PM](https://user-images.githubusercontent.com/40967205/68249993-2380a700-ffdd-11e9-891e-fd98ecf4c885.png)
![Screen Shot 2019-11-05 at 4 38 17 PM](https://user-images.githubusercontent.com/40967205/68255544-be33b280-ffea-11e9-95bf-b48d0d1ae46f.png)

*spree_orders*
![Screen Shot 2019-11-05 at 4 14 40 PM](https://user-images.githubusercontent.com/40967205/68254270-66477c80-ffe7-11e9-818a-e7dccd6d90fc.png)

*solidus_subscriptions_installments*
![Screen Shot 2019-11-05 at 4 20 36 PM](https://user-images.githubusercontent.com/40967205/68254666-554b3b00-ffe8-11e9-8804-9d5889104a5a.png)

*solidus_subscriptions_installment_details*
![Screen Shot 2019-11-05 at 4 22 29 PM](https://user-images.githubusercontent.com/40967205/68254709-7f046200-ffe8-11e9-9668-63a564f8ddf5.png)

**Questions and Answers:**
- https://app.clubhouse.io/enginecommerce/story/5585/subscriptions-should-have-access-to-an-address-for-order-processing