### PR TITLE
WIP Add CREATE to subscriptions_controller

### DIFF
--- a/app/controllers/solidus_subscriptions/api/v1/subscriptions_controller.rb
+++ b/app/controllers/solidus_subscriptions/api/v1/subscriptions_controller.rb
@@ -12,6 +12,7 @@ class SolidusSubscriptions::Api::V1::SubscriptionsController < Spree::Api::BaseC
   end
 
   def update
+    binding.pry
     if @subscription.update(subscription_params)
       persist_subscription_addresses(@subscription)
       if params[:full_json]

--- a/app/controllers/solidus_subscriptions/api/v1/subscriptions_controller.rb
+++ b/app/controllers/solidus_subscriptions/api/v1/subscriptions_controller.rb
@@ -1,6 +1,16 @@
 class SolidusSubscriptions::Api::V1::SubscriptionsController < Spree::Api::BaseController
   before_action :load_subscription, only: [:cancel, :update, :skip]
 
+  def create
+    authorize! :create, SolidusSubscriptions::Subscription
+    @subscription = SolidusSubscriptions::Subscription.new(subscription_params)
+    if @subscription.save
+      render json: @subscription, status: 201
+    else
+      render json: @subscription.errors.to_json, status: 422
+    end
+  end
+
   def update
     if @subscription.update(subscription_params)
       persist_subscription_addresses(@subscription)

--- a/app/controllers/solidus_subscriptions/api/v1/subscriptions_controller.rb
+++ b/app/controllers/solidus_subscriptions/api/v1/subscriptions_controller.rb
@@ -49,9 +49,11 @@ class SolidusSubscriptions::Api::V1::SubscriptionsController < Spree::Api::BaseC
   def subscription_params
     params.require(:subscription).permit(
       :email,
+      :user_id,
       :actionable_date,
       :interval_length,
       :interval_units,
+      :end_date,
       line_items_attributes: line_item_attributes,
       shipping_address_attributes: Spree::PermittedAttributes.address_attributes,
       billing_address_attributes: Spree::PermittedAttributes.address_attributes,

--- a/app/controllers/solidus_subscriptions/api/v1/subscriptions_controller.rb
+++ b/app/controllers/solidus_subscriptions/api/v1/subscriptions_controller.rb
@@ -58,7 +58,7 @@ class SolidusSubscriptions::Api::V1::SubscriptionsController < Spree::Api::BaseC
       shipping_address_attributes: Spree::PermittedAttributes.address_attributes,
       billing_address_attributes: Spree::PermittedAttributes.address_attributes,
       wallet_payment_source_attributes: [:user_id, payment_source_attributes: [:source_type, :nonce, :payment_type, :payment_method_id]]
-    ).merge(team_id: current_team.id)
+    )
   end
 
   def line_item_attributes

--- a/app/controllers/solidus_subscriptions/api/v1/subscriptions_controller.rb
+++ b/app/controllers/solidus_subscriptions/api/v1/subscriptions_controller.rb
@@ -12,7 +12,6 @@ class SolidusSubscriptions::Api::V1::SubscriptionsController < Spree::Api::BaseC
   end
 
   def update
-    binding.pry
     if @subscription.update(subscription_params)
       persist_subscription_addresses(@subscription)
       if params[:full_json]

--- a/app/controllers/solidus_subscriptions/api/v1/subscriptions_controller.rb
+++ b/app/controllers/solidus_subscriptions/api/v1/subscriptions_controller.rb
@@ -56,7 +56,7 @@ class SolidusSubscriptions::Api::V1::SubscriptionsController < Spree::Api::BaseC
       shipping_address_attributes: Spree::PermittedAttributes.address_attributes,
       billing_address_attributes: Spree::PermittedAttributes.address_attributes,
       wallet_payment_source_attributes: [:user_id, payment_source_attributes: [:source_type, :nonce, :payment_type, :payment_method_id]]
-    )
+    ).merge(team_id: current_team.id)
   end
 
   def line_item_attributes

--- a/app/controllers/spree/admin/subscriptions_controller.rb
+++ b/app/controllers/spree/admin/subscriptions_controller.rb
@@ -127,13 +127,15 @@ module Spree
       end
 
       def modify_json_payload
-        binding.pry
         payload = {
           braintree_token: braintree_token,
           braintree_environment: braintree_environment,
           user_token: current_spree_user.spree_api_key,
           braintree_method_id: braintree_payment_method_id,
         }
+        if @subscription.persisted?
+          payload[:subscription] = SubscriptionSerializer.new(@subscription).as_json
+        end
         JSON.generate(payload);
       end
     end

--- a/app/controllers/spree/admin/subscriptions_controller.rb
+++ b/app/controllers/spree/admin/subscriptions_controller.rb
@@ -134,7 +134,7 @@ module Spree
           braintree_method_id: braintree_payment_method_id,
         }
         if @subscription.persisted?
-          payload[:subscription] = SubscriptionSerializer.new(@subscription).as_json
+          payload[:subscription] = SubscriptionSerializer.new(@subscription).as_json(include: '**')
         end
         JSON.generate(payload);
       end

--- a/app/controllers/spree/admin/subscriptions_controller.rb
+++ b/app/controllers/spree/admin/subscriptions_controller.rb
@@ -24,6 +24,7 @@ module Spree
       end
 
       def new
+        @subscription_json = modify_json_payload
         @subscription.line_items.new
       end
 
@@ -104,6 +105,33 @@ module Spree
 
         multiplier
       end
+
+      def braintree_gateway
+        SolidusPaypalBraintree::Gateway.first!
+      end
+
+      def braintree_token
+        braintree_gateway.generate_token
+      end
+
+      def braintree_environment
+        braintree_gateway[:preferences][:environment]
+      end
+
+      def braintree_payment_method_id
+        Spree::PaymentMethod.find_by(active: true, type: 'SolidusPaypalBraintree::Gateway').id
+      end
+
+      def modify_json_payload
+        payload = {
+          braintree_token: braintree_token,
+          braintree_environment: braintree_environment,
+          user_token: current_spree_user.spree_api_key,
+          braintree_method_id: braintree_payment_method_id,
+        }
+        JSON.generate(payload);
+      end
     end
   end
 end
+

--- a/app/controllers/spree/admin/subscriptions_controller.rb
+++ b/app/controllers/spree/admin/subscriptions_controller.rb
@@ -3,7 +3,6 @@ module Spree
     class SubscriptionsController < ResourceController
       skip_before_action :load_resource, only: :index
       before_action :gather_stats, only: :index
-      before_action :set_subscription_json, only: [:new, :edit]
 
       def index
         @search = SolidusSubscriptions::Subscription.
@@ -72,10 +71,6 @@ module Spree
         ::SolidusSubscriptions::Subscription
       end
 
-      def set_subscription_json
-        @subscription_json = modify_json_payload
-      end
-
       def gather_stats
         this_month_range = Time.zone.now.beginning_of_month..Time.zone.now.end_of_month
         today_range = Time.zone.now.beginning_of_day..Time.zone.now.end_of_day
@@ -110,34 +105,6 @@ module Spree
         multiplier
       end
 
-      def braintree_gateway
-        SolidusPaypalBraintree::Gateway.first!
-      end
-
-      def braintree_token
-        braintree_gateway.generate_token
-      end
-
-      def braintree_environment
-        braintree_gateway[:preferences][:environment]
-      end
-
-      def braintree_payment_method_id
-        Spree::PaymentMethod.find_by(active: true, type: 'SolidusPaypalBraintree::Gateway').id
-      end
-
-      def modify_json_payload
-        payload = {
-          braintree_token: braintree_token,
-          braintree_environment: braintree_environment,
-          user_token: current_spree_user.spree_api_key,
-          braintree_method_id: braintree_payment_method_id,
-        }
-        if @subscription.persisted?
-          payload[:subscription] = SubscriptionSerializer.new(@subscription).as_json(include: '**')
-        end
-        JSON.generate(payload);
-      end
     end
   end
 end

--- a/app/controllers/spree/admin/subscriptions_controller.rb
+++ b/app/controllers/spree/admin/subscriptions_controller.rb
@@ -3,6 +3,7 @@ module Spree
     class SubscriptionsController < ResourceController
       skip_before_action :load_resource, only: :index
       before_action :gather_stats, only: :index
+      before_action :set_subscription_json, only: [:new, :edit]
 
       def index
         @search = SolidusSubscriptions::Subscription.
@@ -24,7 +25,6 @@ module Spree
       end
 
       def new
-        @subscription_json = modify_json_payload
         @subscription.line_items.new
       end
 
@@ -70,6 +70,10 @@ module Spree
 
       def model_class
         ::SolidusSubscriptions::Subscription
+      end
+
+      def set_subscription_json
+        @subscription_json = modify_json_payload
       end
 
       def gather_stats
@@ -123,6 +127,7 @@ module Spree
       end
 
       def modify_json_payload
+        binding.pry
         payload = {
           braintree_token: braintree_token,
           braintree_environment: braintree_environment,

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -239,7 +239,7 @@ module SolidusSubscriptions
     end
 
     def create_payment_method_profile
-      return if wallet_payment_source&.payment_source.nil?
+      return if (!wallet_payment_source_id_changed? && !wallet_payment_source&.payment_source_id_changed?) || wallet_payment_source&.payment_source.nil?
 
       payment = OpenStruct.new(source: wallet_payment_source.payment_source)
       payment.source.payment_method.create_profile(payment)

--- a/app/serializers/line_item_serializer.rb
+++ b/app/serializers/line_item_serializer.rb
@@ -1,5 +1,11 @@
 class LineItemSerializer < ActiveModel::Serializer
-  attributes :id, :spree_line_item_id, :subscription_id, :quantity, :interval_units, :interval_length
+  attributes :id, :spree_line_item_id, :subscription_id, :quantity, :interval_units, :interval_length,
+             :subscribable
 
   has_one :spree_line_item
+
+  def subscribable
+    variant = Spree::Variant.find(object.subscribable_id)
+    Spree::VariantSerializer.new(variant).as_json
+  end
 end

--- a/app/serializers/spree/address_serializer.rb
+++ b/app/serializers/spree/address_serializer.rb
@@ -1,6 +1,7 @@
 module Spree
   class AddressSerializer < ActiveModel::Serializer
-    attributes :phone, :zipcode, :state_name, :city, :address2, :address1, :lastname, :firstname, :country_id
+    attributes :phone, :zipcode, :state_name, :city, :address2, :address1, :lastname,
+               :firstname, :country_id, :state_id
 
     has_one :country
   end

--- a/app/serializers/spree/user_serializer.rb
+++ b/app/serializers/spree/user_serializer.rb
@@ -1,0 +1,5 @@
+module Spree
+  class UserSerializer < ActiveModel::Serializer
+    attributes :id, :email
+  end
+end

--- a/app/serializers/spree/variant_serializer.rb
+++ b/app/serializers/spree/variant_serializer.rb
@@ -1,6 +1,6 @@
 module Spree
   class VariantSerializer < ActiveModel::Serializer
-    attributes :id, :sku, :options_text, :product_id, :price_hash
+    attributes :id, :name, :sku, :options_text, :product_id, :price_hash
 
     has_one :product
     has_many :option_values

--- a/app/serializers/subscription_serializer.rb
+++ b/app/serializers/subscription_serializer.rb
@@ -1,9 +1,14 @@
 class SubscriptionSerializer < ActiveModel::Serializer
   attributes :id, :actionable_date, :state, :user_id, :shipping_address_id, :interval_length,
-             :interval_units, :billing_address_id, :email, :total_cost
+             :interval_units, :billing_address_id, :email, :total_cost, :line_items
 
-  has_many :line_items
   has_one :wallet_payment_source
   has_one :billing_address
   has_one :shipping_address
+
+  def line_items
+    object.line_items.map do |line_item|
+      LineItemSerializer.new(line_item).as_json
+    end
+  end
 end

--- a/app/serializers/subscription_serializer.rb
+++ b/app/serializers/subscription_serializer.rb
@@ -1,14 +1,10 @@
 class SubscriptionSerializer < ActiveModel::Serializer
-  attributes :id, :actionable_date, :state, :user_id, :shipping_address_id, :interval_length,
-             :interval_units, :billing_address_id, :email, :total_cost, :line_items
+  attributes :id, :actionable_date, :end_date, :state, :user_id, :shipping_address_id,
+             :interval_length, :interval_units, :billing_address_id, :email, :total_cost, :line_items
 
+  has_one :user
   has_one :wallet_payment_source
   has_one :billing_address
   has_one :shipping_address
-
-  def line_items
-    object.line_items.map do |line_item|
-      LineItemSerializer.new(line_item).as_json
-    end
-  end
+  has_many :line_items
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ SolidusSubscriptions::Engine.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :line_items, only: [:update, :destroy]
-      resources :subscriptions, only: [:update] do
+      resources :subscriptions, only: [:update, :create] do
         member do
           post :cancel
           post :skip

--- a/spec/controllers/solidus_subscriptions/api/v1/subscriptions_controller_spec.rb
+++ b/spec/controllers/solidus_subscriptions/api/v1/subscriptions_controller_spec.rb
@@ -4,6 +4,9 @@ RSpec.describe SolidusSubscriptions::Api::V1::SubscriptionsController, type: :co
   routes { SolidusSubscriptions::Engine.routes }
 
   let!(:user) { create :user }
+  let!(:admin) { create(:admin_user, password: 'secret', password_confirmation: 'secret') }
+  let(:address_country) { create(:country) }
+  let(:address_state) { create(:state, country: address_country) }
   before { user.generate_spree_api_key! }
 
   shared_examples "an authenticated subscription" do
@@ -31,6 +34,54 @@ RSpec.describe SolidusSubscriptions::Api::V1::SubscriptionsController, type: :co
     end
   end
 
+  describe 'POST :create' do
+    subject { post :create, params: params }
+    let!(:payment_method) { create(:credit_card_payment_method, active: true, available_to_users: true) }
+    let(:variant) { create(:variant) }
+    let(:subscription_params) do
+      {
+        user_id: user.id,
+        actionable_date: Date.tomorrow,
+        interval_units: 'month',
+        interval_length: 1,
+        end_date: Date.current + 1.year,
+        line_items_attributes: [{
+          subscribable_id: variant.id,
+          quantity: 6,
+          interval_length: '1',
+          interval_units: 'month',
+          end_date: Date.tomorrow.to_s
+        }],
+        billing_address_attributes: {
+          firstname: 'Ash',
+          lastname: 'Ketchum',
+          address1: '1 Rainbow Road',
+          city: 'Palette Town',
+          country_id: address_country.id,
+          state_id: address_state.id,
+          phone: '999-999-999',
+          zipcode: '10001'
+        }
+      }
+    end
+    let(:params) do
+      {
+        token: admin.spree_api_key,
+        subscription: subscription_params
+      }
+    end
+
+    it { is_expected.to be_successful }
+
+    it 'creates a new subscription' do
+      expect { subject }.to change(SolidusSubscriptions::Subscription, :count).by(1)
+      new_sub = SolidusSubscriptions::Subscription.last
+      expect(new_sub.line_items.count).to eq(1)
+      expect(new_sub.actionable_date).to eq(Date.tomorrow)
+      expect(new_sub.billing_address).to be_present
+    end
+  end
+
   describe 'PATCH :update' do
     subject { patch :update, params: params }
     let(:params) do
@@ -40,9 +91,6 @@ RSpec.describe SolidusSubscriptions::Api::V1::SubscriptionsController, type: :co
         subscription: subscription_params
       }
     end
-
-    let(:address_country) { create(:country) }
-    let(:address_state) { create(:state, country: address_country) }
 
     let(:subscription_params) do
       {


### PR DESCRIPTION
- Add "CREATE" method to SolidusSubscriptions::Api::V1::SubscriptionsController class in solidus_subscriptions
- Add braintree & modify_json_payload methods to SubscriptionsController in Admin (mopdify_json_payload defines what is being passed in to the SubscriptionContainer component
- Add subscription serializers

**Related to PR in engine_storefront: https://github.com/geminimvp/engine_storefront/pull/1786**

[ch10077]